### PR TITLE
Allow all steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: false
 dist: trusty
 language: node_js
 node_js: 8.11
@@ -11,10 +11,26 @@ addons:
   firefox: latest
   chrome: stable
 
-env:
-  - POLYMER=2 TEST_SUITE=unit_tests
-  - POLYMER=2 TEST_SUITE=visual_tests
-  - POLYMER=3
+jobs:
+  include:
+    - if: type = push
+      env: TEST_SUITE=unit_tests POLYMER=2
+    - if: type = push
+      env: TEST_SUITE=visual_tests POLYMER=2
+    - if: type = push
+      env: TEST_SUITE=unit_tests POLYMER=3
+    - if: type = pull_request
+      env: POLYMER=2
+      addons:
+        firefox: latest
+        chrome: stable
+    - if: type = pull_request
+      env: POLYMER=3
+      addons:
+        firefox: latest
+        chrome: stable
+    - if: type = cron
+      env: TEST_SUITE=unit_tests POLYMER=2
 
 script:
   - if [[ "$POLYMER" = "2" ]]; then
@@ -24,7 +40,7 @@ script:
       if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_BRANCH" != quick/* ]]; then
         if [[ "$TEST_SUITE" = "visual_tests" ]]; then
           npm i -q --no-save gemini@^4.0.0 gemini-sauce gemini-polyserve &&
-          gemini test test/visual
+          gemini test test/visual;
         else
           wct --env saucelabs;
         fi;
@@ -41,9 +57,9 @@ script:
       magi p3-convert --out . --import-style=name &&
       yarn install --flat &&
       if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_BRANCH" != quick/* ]]; then
-        wct --module-resolution=node --npm --env saucelabs;
+        wct --npm --env saucelabs;
       else
-        xvfb-run -s '-screen 0 1024x768x24' wct --module-resolution=node --npm;
+        xvfb-run -s '-screen 0 1024x768x24' wct --npm;
       fi;
     fi
 

--- a/src/vaadin-time-picker.html
+++ b/src/vaadin-time-picker.html
@@ -228,7 +228,7 @@ This program is available under Apache License Version 2.0, available at https:/
             },
 
             /**
-             * Specifies the number of valid intervals in a day or in an hour used for
+             * Specifies the number of valid intervals in a day used for
              * configuring the items displayed in the selection box.
              *
              * It also configures the precision of the value string. By default
@@ -237,7 +237,11 @@ This program is available under Apache License Version 2.0, available at https:/
              * `hh:mm:ss` and `hh:mm:ss.fff` respectively.
              *
              * Unit must be set in seconds, and for correctly configuring intervals
-             * in the dropdown, it need to evenly divide a day or an hour.
+             * in the dropdown, it need to evenly divide a day.
+             *
+             * Note: it is possible to define step that is dividing an hour in inexact
+             * fragments (i.e. 5760 seconds which equals 1 hour 36 minutes), but it is
+             * not recommended to use it for better UX experience.
              */
             step: {
               type: Number,
@@ -349,7 +353,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
 
         __onArrowPressWithStep(step) {
-          const objWithStep = this.__addStep(this.__getMsec(this.__memoValue), step);
+          const objWithStep = this.__addStep(this.__getMsec(this.__memoValue), step, true);
           this.__memoValue = objWithStep;
           this.__inputElement.value = this.i18n.formatTime(this.__validateTime(objWithStep));
         }
@@ -368,9 +372,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Returning Object in the format `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`
-         * from the result of adding step value in milliseconds to the milliseconds amount
+         * from the result of adding step value in milliseconds to the milliseconds amount.
+         * With `precision` parameter rounding the value to the closest step valid interval.
          */
-        __addStep(msec, step) {
+        __addStep(msec, step, precision) {
           // If the time is `00:00` and step changes value downwards, it should be considered as `24:00`
           if (msec === 0 && step < 0) {
             msec = 24 * 60 * 60 * 1000;
@@ -378,9 +383,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
           const stepMsec = step * 1000;
           const diffToNext = msec % stepMsec;
-          if (stepMsec < 0 && diffToNext) {
+          if (stepMsec < 0 && diffToNext && precision) {
             msec -= diffToNext;
-          } else if (stepMsec > 0 && diffToNext) {
+          } else if (stepMsec > 0 && diffToNext && precision) {
             msec -= diffToNext - stepMsec;
           } else {
             msec += stepMsec;
@@ -410,25 +415,16 @@ This program is available under Apache License Version 2.0, available at https:/
           // Default step in overlay items is 1 hour
           const step = this.step || 3600;
 
-          let hourIncr = step / 3600;
-          // disallow non evenly hour increments
-          hourIncr = hourIncr < 1 || 24 % hourIncr != 0 ? 1 : hourIncr;
-
-          for (let hour = 0; hour < 24; hour += hourIncr) {
-
-            let minIncr = hourIncr == 1 ? step / 60 : 60;
-            // disallow non evenly minute increments, and set smallest increment to 15 min
-            minIncr = minIncr < 15 ? 15 : 60 % minIncr != 0 ? 60 : minIncr;
-
-            for (let min = 0; min < 60; min += minIncr) {
-              const timeObj = this.__validateTime({hours: hour, minutes: (min === 60) ? 0 : min});
-              generatedList.push({
-                // we only pick items with minute resolution
-                label: this.i18n.formatTime(timeObj),
-                // but we set value with step defined resolution
-                value: this.i18n.formatTime(timeObj)
-              });
-            }
+          let time = -step;
+          while (time + step < 24 * 60 * 60) {
+            const timeObj = this.__validateTime(this.__addStep(time * 1000, step));
+            time += step;
+            generatedList.push({
+              // we only pick items with minute resolution
+              label: this.i18n.formatTime(timeObj),
+              // but we set value with step defined resolution
+              value: this.i18n.formatTime(timeObj)
+            });
           }
 
           return generatedList;

--- a/test/dropdown-test.html
+++ b/test/dropdown-test.html
@@ -70,9 +70,15 @@
         expect(timePicker.__dropdownElement.filteredItems[71].value).to.be.equal('23:40');
       });
 
-      it('should not be possible to divide one hour in inexact fragments', () => {
+      it('should be possible to divide one hour in inexact fragments if the day can be divided into those', () => {
         timePicker.step = 60 * 18;
-        expect(timePicker.__dropdownElement.filteredItems.length).to.be.equal(24);
+        expect(timePicker.__dropdownElement.filteredItems.length).to.be.equal(80);
+      });
+
+      it('should be possible to divide one day in exact fragments that are greater than 1 hour', () => {
+        // 1 hour 36 minutes
+        timePicker.step = 3600 + 60 * 36;
+        expect(timePicker.__dropdownElement.filteredItems.length).to.be.equal(15);
       });
 
       it('on step change the resolution should be changed, but selectedItem should remain the same', () => {

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -4,8 +4,17 @@ var env = envIndex ? process.argv[envIndex] : undefined;
 module.exports = {
   testTimeout: 180 * 1000,
   verbose: false,
-  // MAGI REMOVE START
   plugins: {
+    local: {
+      browserOptions: {
+        chrome: [
+          'headless',
+          'disable-gpu',
+          'no-sandbox'
+        ]
+      }
+    },
+    // MAGI REMOVE START
     istanbul: {
       dir: './coverage',
       reporters: ['text-summary', 'lcov'],
@@ -15,12 +24,12 @@ module.exports = {
       exclude: [],
       thresholds: {
         global: {
-          statements: 98
+          statements: 100
         }
       }
     }
+    // MAGI REMOVE END
   },
-  // MAGI REMOVE END
 
   registerHooks: function(context) {
     const saucelabsPlatformsMobile = [


### PR DESCRIPTION
Fixes #79 

Allowing steps that are dividing an hour in inexact fragments (like 1 hour 36 mins).
Use `__addStep` without `precision` for populating dropdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker/84)
<!-- Reviewable:end -->
