### PR TITLE
Respect min and max during validation, add tests

### DIFF
--- a/src/vaadin-time-picker.html
+++ b/src/vaadin-time-picker.html
@@ -424,7 +424,7 @@ This program is available under Apache License Version 2.0, available at https:/
           let result = (obj && obj.hours || 0) * 60 * 60 * 1000;
           result += (obj && obj.minutes || 0) * 60 * 1000;
           result += (obj && obj.seconds || 0) * 1000;
-          result += (obj && obj.milliseconds || 0);
+          result += (obj && parseInt(obj.milliseconds) || 0);
 
           return result;
         }
@@ -627,6 +627,14 @@ This program is available under Apache License Version 2.0, available at https:/
           return !(this.invalid = !this.checkValidity());
         }
 
+        _timeAllowed(time) {
+          const parsedMin = this.i18n.parseTime(this.min);
+          const parsedMax = this.i18n.parseTime(this.max);
+
+          return (!this.__getMsec(parsedMin) || this.__getMsec(time) >= this.__getMsec(parsedMin)) &&
+            (!this.__getMsec(parsedMax) || this.__getMsec(time) <= this.__getMsec(parsedMax));
+        }
+
         /**
          * Returns true if the current input value satisfies all constraints (if any)
          *
@@ -634,6 +642,7 @@ This program is available under Apache License Version 2.0, available at https:/
          */
         checkValidity() {
           return this.__inputElement.focusElement.checkValidity() &&
+            (!this.value || this._timeAllowed(this.i18n.parseTime(this.value))) &&
             (!this.__dropdownElement.value || this.i18n.parseTime(this.__dropdownElement.value));
         }
       }

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -92,6 +92,32 @@
         expect(timepicker.invalid).to.be.equal(false);
       });
 
+      it('should respect min value during validation', () => {
+        timepicker.step = '0.5';
+        timepicker.min = '01:00';
+        timepicker.value = '00:59:59.500';
+
+        expect(timepicker.validate()).to.equal(false);
+        expect(timepicker.invalid).to.be.equal(true);
+
+        timepicker.value = '01:00:00.000';
+        expect(timepicker.validate()).to.equal(true);
+        expect(timepicker.invalid).to.be.equal(false);
+      });
+
+      it('should respect max value during validation', () => {
+        timepicker.step = '0.5';
+        timepicker.max = '01:00';
+        timepicker.value = '01:00:00.500';
+
+        expect(timepicker.validate()).to.equal(false);
+        expect(timepicker.invalid).to.be.equal(true);
+
+        timepicker.value = '01:00:00.000';
+        expect(timepicker.validate()).to.equal(true);
+        expect(timepicker.invalid).to.be.equal(false);
+      });
+
       it('should not mark empty input as invalid', () => {
         expect(timepicker.validate()).to.equal(true);
 


### PR DESCRIPTION
Fixes #112
Added `parseInt` for `milliseconds` in `__getMsec` as now the time object can be created from `min` and `max` values where the `milliseconds` can be Strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker/113)
<!-- Reviewable:end -->
