### PR TITLE
Override validate function for the input

### DIFF
--- a/src/vaadin-time-picker.html
+++ b/src/vaadin-time-picker.html
@@ -371,6 +371,9 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
 
+          // In order to have synchronized invalid property, we need to use the same validate logic.
+          this.__inputElement.validate = () => {};
+
           // Not using declarative because we receive an event before text-element shadow is ready,
           // thus querySelector in textField.focusElement raises an undefined exception on validate
           this.__dropdownElement.addEventListener('value-changed', e => this.__onInputChange(e));

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -80,6 +80,18 @@
         expect(timepicker.__inputElement.required).to.be.false;
       });
 
+      it('should have synced invalid property wiht input on validation with required flag', () => {
+        timepicker.name = 'foo';
+        timepicker.required = true;
+        timepicker.min = '14:00';
+        timepicker.value = '13:00';
+
+        expect(timepicker.__inputElement.invalid).to.equal(true);
+
+        timepicker.value = '12:00';
+        expect(timepicker.__inputElement.invalid).to.equal(true);
+      });
+
       it('should validate correctly with required flag', () => {
         timepicker.name = 'foo';
         timepicker.required = true;


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-time-picker/issues/120

Use similar approach as in `vaadin-date-picker`: 
https://github.com/vaadin/vaadin-date-picker/blob/3830b917c791efa59293f2c064760b6806dd5b4e/src/vaadin-date-picker.html#L257