### PR TITLE
docs: mark autoOpenDisabled as private [skip ci]

### DIFF
--- a/src/vaadin-time-picker.html
+++ b/src/vaadin-time-picker.html
@@ -289,6 +289,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set true to prevent the overlay from opening automatically.
+             *
+             * TODO: make it public in the next minor, and add a demo.
+             *
+             * @private
              */
             autoOpenDisabled: Boolean,
 


### PR DESCRIPTION
We are going to release `2.1` with RTL support only, and postpone `autoOpenDisabled`.

- Vaadin 14.3 will include both (most likely)
- Vaadin 16 will only include RTL

So, agreed that API is not reverted but considered private for now.