### PR TITLE
fix: allow overriding _getInputElement()

### DIFF
--- a/src/vaadin-time-picker.html
+++ b/src/vaadin-time-picker.html
@@ -645,7 +645,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return TimePickerElement.properties.i18n.value().parseTime(text);
         }
 
-        /** @private */
+        /** @protected */
         _getInputElement() {
           return this.shadowRoot.querySelector('vaadin-time-picker-text-field');
         }


### PR DESCRIPTION
This was accidentally marked as `@private` for TS defs generation but it was originally correctly intended as `@protected`. This is overridden in vaadin-date-time-picker. See: https://github.com/vaadin/vaadin-time-picker/commit/8730119629d99baf4eb7f4f05d515ece7169d49e#diff-f47a6ede93b6671ca3a69fb260ffacfc