### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-time-picker.html
+++ b/src/vaadin-time-picker.html
@@ -188,6 +188,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to prevent the user from entering invalid input.
+             * @attr {boolean} prevent-invalid-input
              */
             preventInvalidInput: {
               type: Boolean
@@ -202,6 +203,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The error message to display when the input is invalid.
+             * @attr {string} error-message
              */
             errorMessage: {
               type: String
@@ -287,6 +289,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to display the clear icon which clears the input.
+             * @attr {boolean} clear-button-visible
              * @type {boolean}
              */
             clearButtonVisible: {
@@ -296,6 +299,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set true to prevent the overlay from opening automatically.
+             * @attr {boolean} auto-open-disabled
              */
             autoOpenDisabled: Boolean,
 


### PR DESCRIPTION
Connected to vaadin/vaadin-core#257

Note, this is a PR for `2.3` branch. When cherry-picking it to master, we need to also include `helperText` property.