### PR TITLE
ci: run for branches but not tags [skip ci]

### DIFF
--- a/.github/workflows/sauce.yml
+++ b/.github/workflows/sauce.yml
@@ -2,8 +2,10 @@ name: sauce
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
-      - 'v**'
+      - '*.*'
 
 jobs:
   unit-tests:


### PR DESCRIPTION
The previously merged PR was incorrect as it disabled the push build altogether 😕  This one should fix it.