### PR TITLE
chore: add JSDoc for custom events [skip ci]

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -15,12 +15,12 @@ export interface TimePickerI18n {
 /**
  * Fired when the `invalid` property changes.
  */
-export type TimePickerInvalidChanged = CustomEvent<{ value: boolean; path: 'invalid' }>;
+export type TimePickerInvalidChanged = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type TimePickerValueChanged = CustomEvent<{ value: string; path: 'value' }>;
+export type TimePickerValueChanged = CustomEvent<{ value: string }>;
 
 export interface TimePickerElementEventMap {
   'invalid-changed': TimePickerInvalidChanged;

--- a/src/vaadin-time-picker.d.ts
+++ b/src/vaadin-time-picker.d.ts
@@ -50,6 +50,9 @@ import { TimePickerEventMap, TimePickerI18n, TimePickerTime } from './interfaces
  *
  * Note: the `theme` attribute value set on `<vaadin-time-picker>` is
  * propagated to the internal themable components listed above.
+ *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class TimePickerElement extends ElementMixin(ControlStateMixin(ThemableMixin(HTMLElement))) {
   /**

--- a/src/vaadin-time-picker.js
+++ b/src/vaadin-time-picker.js
@@ -55,6 +55,9 @@ import './vaadin-time-picker-text-field.js';
  * Note: the `theme` attribute value set on `<vaadin-time-picker>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ *
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ControlStateMixin


### PR DESCRIPTION
1. Added `@fires` annotations to enable VS Code lit-plugin code completion support.
2. Removed `path` from events typings as Polymer-specific and generally unused.