### PR TITLE
refactor: cleanup IE11 vendor prefixes

### DIFF
--- a/src/vaadin-time-picker-text-field.js
+++ b/src/vaadin-time-picker-text-field.js
@@ -22,12 +22,6 @@ registerStyles(
       direction: rtl;
       text-align: left;
     }
-
-    :host([dir='rtl']) [part='value']:-ms-input-placeholder,
-    :host([dir='rtl']) [part='input-field'] ::slotted(input):-ms-input-placeholder {
-      direction: rtl;
-      text-align: left;
-    }
   `,
   { moduleId: 'vaadin-time-picker-text-field-styles' }
 );


### PR DESCRIPTION
We no longer support IE11 and legacy Edge so let's remove `-ms` vendor prefixes.