### PR TITLE
chore: align JSDoc, add change event [skip ci]

### DIFF
--- a/src/vaadin-time-picker.d.ts
+++ b/src/vaadin-time-picker.d.ts
@@ -51,6 +51,7 @@ import { TimePickerEventMap, TimePickerI18n, TimePickerTime } from './interfaces
  * Note: the `theme` attribute value set on `<vaadin-time-picker>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-time-picker.js
+++ b/src/vaadin-time-picker.js
@@ -55,6 +55,7 @@ import './vaadin-time-picker-text-field.js';
  * Note: the `theme` attribute value set on `<vaadin-time-picker>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *


### PR DESCRIPTION
Added a `change` event to align with the [API docs](https://cdn.vaadin.com/vaadin-time-picker/3.0.0-alpha1/#/elements/vaadin-time-picker#events).