### PR TITLE
test: make sure no initial validation happens for time-picker

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "rules": {
     "no-undef": 0,
     "no-unused-vars": 0

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,5 @@
+async function nextRender(element) {
+  return new Promise(resolve => {
+    Polymer.RenderStatus.afterNextRender(element, resolve);
+  });
+}

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -8,6 +8,7 @@
 
   <link rel="import" href="../../iron-form/iron-form.html">
   <link rel="import" href="../vaadin-time-picker.html">
+  <script src="common.js"></script>
 </head>
 
 <body>
@@ -149,6 +150,40 @@
         expect(timepicker.validate()).to.equal(true);
       });
 
+      describe('initial validation', () => {
+        let validateSpy;
+        let timePicker;
+
+        beforeEach(() => {
+          timePicker = document.createElement('vaadin-time-picker');
+          validateSpy = sinon.spy(timePicker, 'validate');
+        });
+
+        afterEach(() => {
+          timePicker.remove();
+        });
+
+        it('should not validate by default', async() => {
+          document.body.appendChild(timePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate when the field has an initial value', async() => {
+          timePicker.value = '12:00';
+          document.body.appendChild(timePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate when the field has an initial value and invalid', async() => {
+          timePicker.value = '12:00';
+          timePicker.invalid = true;
+          document.body.appendChild(timePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+      });
       describe('custom validator', () => {
 
         beforeEach(() => timepicker = fixture('custom-validation'));


### PR DESCRIPTION
Backports web-components#4160 as part of an EoD task
 

> ## Description
> This PR adds unit tests verifying that no initial validation happens for `time-picker`.
> 
> Part of #4150
> 
> ## Type of change
> * [x]  Internal
> 
> ## Checklist
> * [x]  I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
> * [x]  I have added a description following the guideline.
> * [x]  The issue is created in the corresponding repository and I have referenced it.
> * [x]  I have added tests to ensure my change is effective and works as intended.
> * [x]  New and existing tests are passing locally with my change.
> * [x]  I have performed self-review and corrected misspellings.

